### PR TITLE
Patch 1

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -13,7 +13,7 @@ class ApiController extends Controller
 {
 
     public function headerReport(Request $request) {
-        
+
         $this->checkSiwecosRequest($request);
 
         $check = new HeaderCheck($request->json('url'));
@@ -24,7 +24,7 @@ class ApiController extends Controller
     }
 
     public function domxssReport(Request $request){
-        
+
         $this->checkSiwecosRequest($request);
 
         $check = new DomxssCheck($request->json('url'));
@@ -62,6 +62,27 @@ class ApiController extends Controller
             }
             catch (\Exception $e) {
                 Log::debug($e);
+                Log::debug("Trying to send an error");
+                try {
+                  $client->post($url, [
+                      'http_errors' => false,
+                      'timeout' => 60,
+                      'json' => [
+                        "name" => "HEADER",
+                        "hasError" => "true",
+                        "score" => 0,
+                        "errorMessage" => [
+                                "placeholder" => "GENERAL_ERROR",
+                                "values" => [
+                                        "ERRORTEXT" => $e->getMessage()
+                                ]
+                        ]
+                     ]
+                  ]);
+                }
+                catch (\Exception $e) {
+                    Log::debug($e);
+                }
             }
         }
     }

--- a/app/Ratings/Rating.php
+++ b/app/Ratings/Rating.php
@@ -31,7 +31,11 @@ abstract class Rating
 
     public function getHeader($header)
     {
-        return $this->response->header($header);
+        $result= $this->response->header($header);
+        $encoded= json_encode($result);
+        if ( $encoded !== false ) return $result;
+        return "Encoding error";
     }
 
 }
+

--- a/app/Ratings/Rating.php
+++ b/app/Ratings/Rating.php
@@ -34,8 +34,7 @@ abstract class Rating
         $result= $this->response->header($header);
         $encoded= json_encode($result);
         if ( $encoded !== false ) return $result;
-        return "Encoding error";
+        return $header;
     }
 
 }
-

--- a/app/Ratings/XContentTypeOptionsRating.php
+++ b/app/Ratings/XContentTypeOptionsRating.php
@@ -25,11 +25,11 @@ class XContentTypeOptionsRating extends Rating
             $this->errorMessage = "HEADER_NOT_SET";
         } elseif ( gettype($header) === "string" ) {
             $this->hasError = true;
-            $this->errorMessage = "GENERAL_ERROR";
+            $this->errorMessage = "HEADER_ENCODING_ERROR";
             $this->testDetails->push([
-           		'placeholder' => 'GENERAL_ERROR',
+           		'placeholder' => 'HEADER_ENCODING_ERROR',
           		'values' => [
-          			'ERRORTEXT' => $header
+          			'HEADER' => $header
           		]
 	           ]);
         } elseif (count($header) > 1) {

--- a/app/Ratings/XContentTypeOptionsRating.php
+++ b/app/Ratings/XContentTypeOptionsRating.php
@@ -1,90 +1,51 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Ratings;
 
-use App\HeaderCheck;
-use App\DomxssCheck;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Validator;
 use GuzzleHttp\Client;
-use Illuminate\Support\Facades\Log;
+use App\HTTPResponse;
 
-class ApiController extends Controller
+
+class XContentTypeOptionsRating extends Rating
 {
 
-    public function headerReport(Request $request) {
+    public function __construct(HTTPResponse $response) {
+        parent::__construct($response);
 
-        $this->checkSiwecosRequest($request);
-
-        $check = new HeaderCheck($request->json('url'));
-
-        $this->notifyCallbacks($request->json('callbackurls'), $check);
-
-        return "OK";
+        $this->name = "X_CONTENT_TYPE_OPTIONS";
+        $this->scoreType = "warning";
     }
 
-    public function domxssReport(Request $request){
+    protected function rate()
+    {
+        $header = $this->getHeader('x-content-type-options');
 
-        $this->checkSiwecosRequest($request);
+        if ($header === null) {
+            $this->hasError = true;
+            $this->errorMessage = "HEADER_NOT_SET";
+        } elseif ( gettype($header) === "string" ) {
+            $this->hasError = true;
+            $this->errorMessage = "GENERAL_ERROR";
+            $this->testDetails->push([
+           		'placeholder' => 'GENERAL_ERROR',
+          		'values' => [
+          			'ERRORTEXT' => $header
+          		]
+	           ]);
+        } elseif (count($header) > 1) {
+            $this->hasError = true;
+            $this->errorMessage = "HEADER_SET_MULTIPLE_TIMES";
+            $this->testDetails->push(['placeholder' => 'HEADER_SET_MULTIPLE_TIMES', 'values' => ['HEADER' => $header]]);
+        } else {
+            $header = $header[0];
 
-        $check = new DomxssCheck($request->json('url'));
-
-        $this->notifyCallbacks($request->json('callbackurls'), $check);
-
-        return "OK";
-    }
-
-    protected function checkSiwecosRequest(Request $request) {
-        $validator = Validator::make($request->all(), [
-            'url' => 'required|url',
-            'dangerLevel' => 'integer|min:0|max:10',
-            'callbackurls' => 'required|array',
-            'callbackurls.*' => 'url'
-        ]);
-
-        if ($validator->fails()) {
-            return $validator->errors();
-        }
-
-        return true;
-    }
-
-    protected function notifyCallbacks(array $callbackurls, $check) {
-        $report = $check->report();
-        foreach ($callbackurls as $url) {
-            try {
-                $client = new Client();
-                $client->post($url, [
-                    'http_errors' => false,
-                    'timeout' => 60,
-                    'json' => $report
-                ]);
+            if (strpos($header, 'nosniff') !== false) {
+                $this->score = 100;
+                $this->testDetails->push(['placeholder' => 'XCTO_CORRECT', 'values' => ['HEADER' => $header]]);
             }
-            catch (\Exception $e) {
-                Log::debug($e);
-                Log::debug("Trying to send an error");
-                try {
-                  $client->post($url, [
-                      'http_errors' => false,
-                      'timeout' => 60,
-                      'json' => [
-                        "name" => "HEADER",
-                        "hasError" => "true",
-                        "score" => 0,
-                        "errorMessage" => [
-                                "placeholder" => "GENERAL_ERROR",
-                                "values" => [
-                                        "ERRORTEXT" => $e->getMessage()
-                                ]
-                        ]
-                     ]
-                  ]);
-                }
-                catch (\Exception $e) {
-                    Log::debug($e);
-                }
+            else {
+                $this->testDetails->push(['placeholder' => 'XCTO_NOT_CORRECT', 'values' => ['HEADER' => $header]]);
             }
         }
     }
-
 }


### PR DESCRIPTION
This change will try to send an error if sending the result failed (ApiController.php)

It will also try to json encoder every header (Rating.php) Usually the function returns null or an array. If it returns a string now, this is an error message which can be shown to the customer.

In XContentTypeOptionsRating an example is shown how to handle this kind of error. It has to be adaptet for the other Ratings as well to be complete.

This would fix the latest issue (#24)